### PR TITLE
Multi-user support and certificate user validation

### DIFF
--- a/frontend/src/adapter.js
+++ b/frontend/src/adapter.js
@@ -26,7 +26,7 @@ export class Adapter {
     doc
     awareness
 
-    constructor(d) {
+    constructor(d, userid) {
         this.doc = d;
         this.doc.on('update', u => {
             console.log(`Sending: ${u}`);
@@ -41,7 +41,7 @@ export class Adapter {
             W.broadcast(insertByte(2, msg));
         });
 
-        W.start();
+        W.start(userid);
         W.setDataHandler(this.onUpdate.bind(this));
         W.setPeerHandler(this.onNewPeer.bind(this));
     }
@@ -91,7 +91,7 @@ export class Adapter {
             await W.uploadCert();
         }
 
-        return new Adapter(d);
+        return new Adapter(d, userid);
     }
 }
 

--- a/frontend/src/webrtc.js
+++ b/frontend/src/webrtc.js
@@ -39,21 +39,21 @@ function openCertDatabase(onSuccess, onError) {
     req.onerror = () => onError(req.error);
 }
 
-function saveCertificate(db, cert, onSuccess, onError) {
+function saveCertificate(db, key, cert, onSuccess, onError) {
     let certTx = db.transaction('dtlsCerts', 'readwrite');
     let certStore = certTx.objectStore('dtlsCerts');
     let certPut = certStore.put({
-        id: 0,
+        id: key,
         cert: cert,
     });
     certPut.onsuccess = onSuccess;
     certPut.onerror = () => onError(certPut.error);
 }
 
-function loadCertificate(db, onSuccess, onError) {
+function loadCertificate(db, key, onSuccess, onError) {
     let certTx = db.transaction('dtlsCerts', 'readonly');
     let certStore = certTx.objectStore('dtlsCerts');
-    let certGet = certStore.get(0)
+    let certGet = certStore.get(key)
     certGet.onsuccess = () => {
         let match = certGet.result;
         if (match !== undefined) {
@@ -67,11 +67,11 @@ function loadCertificate(db, onSuccess, onError) {
 
 // ========================== Interface ==========================
 
-export function loadCert() {
+export function loadCert(key) {
     console.assert(certDB !== null, 'IndexedDB not available');
 
     return new Promise((res, rej) => {
-        loadCertificate(certDB,
+        loadCertificate(certDB, key,
             cert => {
                 if (cert !== null) {
                     getCertificateChecksum(cert).then(fp => {
@@ -98,12 +98,12 @@ export function loadCert() {
     });
 }
 
-export function saveCert() {
+export function saveCert(key) {
     console.assert(localCert !== null, 'No local certificate available');
     console.assert(certDB !== null, 'IndexedDB not available');
 
     return new Promise((res, rej) => {
-        saveCertificate(certDB, localCert,
+        saveCertificate(certDB, key, localCert,
             () => {
                 res(true)
             },

--- a/src/cert-storage.ts
+++ b/src/cert-storage.ts
@@ -13,7 +13,8 @@ const expirationGranularity: number = 300; // s
 const certs: CertInfo[] = [];
 
 export async function addCert(cert: CertInfo): Promise<void> {
-    certs.push(cert);
+    if (await getCertByFP(cert.key) === null)  // Prevent duplicates
+        certs.push(cert);
 }
 
 export async function getAllCerts(): Promise<CertInfo[]> {


### PR DESCRIPTION
This PR adds two related features to workspace:

- Added the ability to store multiple certificates in IndexedDB. This allows users to logout, login to another user account, then log back into the original without overwriting the original cert
- Added certificate user verification. Certificates are now associated with a user account. Attempting to authenticate with another user's certificate will result in the connection being immediately terminated.

Currently there is no attempt at obfuscating the user-certificate mapping in indexed db. This is trivial to implement server-side but is outside the scope of this project/PR.